### PR TITLE
Update directory path in bin.xml

### DIFF
--- a/modules/ballerina/src/assembly/bin.xml
+++ b/modules/ballerina/src/assembly/bin.xml
@@ -52,7 +52,7 @@
 
         <fileSet>
             <directory>
-                ${project.build.directory}/extracted-distributions/ballerina-builtin-jar/META-INF/natives
+                ${project.build.directory}/extracted-distributions/ballerina-builtin-jar/META-INF/ballerina
             </directory>
             <outputDirectory>src</outputDirectory>
         </fileSet>


### PR DESCRIPTION
This PR updates the directory path in `bin.xml` to fix the issue of native packages not copying to the `src` directory in the distribution.