### PR TITLE
 Adding capability to extract the PID using lsof if ss command fails

### DIFF
--- a/modules/tests/test-integration/src/test/java/org/ballerinalang/test/context/ServerInstance.java
+++ b/modules/tests/test-integration/src/test/java/org/ballerinalang/test/context/ServerInstance.java
@@ -522,6 +522,12 @@ public class ServerInstance implements Server {
         Utils.deleteFolder(workDir);
     }
 
+    /**
+     * This method returns the pid of the service which is using the provided port
+     * @param httpServerPort port of the service running
+     * @return the pid of the service
+     * @throws BallerinaTestException
+     */
     private String getPidWithLsof(int httpServerPort) throws BallerinaTestException {
         String pid;
         Process tmp = null;


### PR DESCRIPTION
This PR fixes build failures happening on MacOS due to unavailability of ss command.