### PR TITLE
Add ballerina-config module

### DIFF
--- a/modules/ballerina/pom.xml
+++ b/modules/ballerina/pom.xml
@@ -36,6 +36,10 @@
         </dependency>
         <dependency>
             <groupId>org.ballerinalang</groupId>
+            <artifactId>ballerina-config</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.ballerinalang</groupId>
             <artifactId>ballerina-lang</artifactId>
         </dependency>
         <dependency>

--- a/modules/ballerina/src/assembly/bin.xml
+++ b/modules/ballerina/src/assembly/bin.xml
@@ -145,6 +145,7 @@
             <outputDirectory>bre/lib</outputDirectory>
             <scope>runtime</scope>
             <includes>
+                <include>org.ballerinalang:ballerina-config:jar</include>
                 <include>org.ballerinalang:ballerina-core:jar</include>
                 <include>org.ballerinalang:ballerina-lang:jar</include>
                 <include>org.ballerinalang:ballerina-launcher:jar</include>

--- a/pom.xml
+++ b/pom.xml
@@ -74,6 +74,11 @@
             </dependency>
             <dependency>
                 <groupId>org.ballerinalang</groupId>
+                <artifactId>ballerina-config</artifactId>
+                <version>${ballerina.runtime.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.ballerinalang</groupId>
                 <artifactId>ballerina-lang</artifactId>
                 <version>${ballerina.runtime.version}</version>
             </dependency>


### PR DESCRIPTION
This PR adds ballerina-config module as a dependency and adds it to the bin.xml to be packaged with the runtime.