### PR TITLE
Start Composer with unknown args to script on windows

### DIFF
--- a/modules/ballerina-tools/bin/composer.bat
+++ b/modules/ballerina-tools/bin/composer.bat
@@ -84,13 +84,8 @@ if ""%1""==""--debug""  goto commandDebug
 
 if ""%1""==""help""  goto commandHelp
 
-goto commandUnknownArg
-
-
-rem ----- commandUnknownArg ----------------------------------------------------
-:commandUnknownArg
-echo Not supported option or command or value : %1
-goto commandHelp
+shift
+goto setupArgs
 
 rem ----- commandUnknownArg ----------------------------------------------------
 :commandHelp


### PR DESCRIPTION
There are some startup args taken by composer
backend services runner. Breaking startup upon
unknown args in shell script prevents latter
mentioned capability of composer.
Raised originally in https://github.com/ballerinalang/composer/issues/4568