### PR TITLE
Change --debug to --java.debug

### DIFF
--- a/modules/ballerina/bin/ballerina
+++ b/modules/ballerina/bin/ballerina
@@ -127,20 +127,20 @@ fi
 
 for c in "$@"
 do
-    if [ "$c" = "--debug" ] || [ "$c" = "-debug" ] || [ "$c" = "debug" ]; then
-          CMD="--debug"
-    elif [ "$CMD" = "--debug" ] && [ -z "$PORT" ]; then
+    if [ "$c" = "--java.debug" ] || [ "$c" = "-java.debug" ] || [ "$c" = "java.debug" ]; then
+          CMD="--java.debug"
+    elif [ "$CMD" = "--java.debug" ] && [ -z "$PORT" ]; then
           PORT=$c
     fi
 done
 
-if [ "$CMD" = "--debug" ]; then
+if [ "$CMD" = "--java.debug" ]; then
   if [ "$PORT" = "" ]; then
-    echo "Please specify the debug port after the --debug option"
+    echo "Please specify the debug port after the --java.debug option"
     exit 1
   fi
   if [ -n "$JAVA_OPTS" ]; then
-    echo "Warning !!!. User specified JAVA_OPTS will be ignored, once you give the --debug option."
+    echo "Warning !!!. User specified JAVA_OPTS will be ignored, once you give the --java.debug option."
   fi
   JAVA_OPTS="-Xdebug -Xnoagent -Djava.compiler=NONE -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=$PORT"
   echo "Please start the remote debugging client to continue..."

--- a/modules/ballerina/bin/ballerina.bat
+++ b/modules/ballerina/bin/ballerina.bat
@@ -74,9 +74,9 @@ rem of arguments (up to the command line limit, anyway).
 :setupArgs
 if ""%1""=="""" goto doneStart
 
-if ""%1""==""debug""    goto commandDebug
-if ""%1""==""-debug""   goto commandDebug
-if ""%1""==""--debug""  goto commandDebug
+if ""%1""==""java.debug""    goto commandDebug
+if ""%1""==""-java.debug""   goto commandDebug
+if ""%1""==""--java.debug""  goto commandDebug
 
 shift
 goto setupArgs
@@ -87,13 +87,13 @@ rem ----- commandDebug ---------------------------------------------------------
 shift
 set DEBUG_PORT=%1
 if "%DEBUG_PORT%"=="" goto noDebugPort
-if not "%JAVA_OPTS%"=="" echo Warning !!!. User specified JAVA_OPTS will be ignored, once you give the --debug option.
+if not "%JAVA_OPTS%"=="" echo Warning !!!. User specified JAVA_OPTS will be ignored, once you give the --java.debug option.
 set JAVA_OPTS=-Xdebug -Xnoagent -Djava.compiler=NONE -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=%DEBUG_PORT%
 echo Please start the remote debugging client to continue...
 goto runServer
 
 :noDebugPort
-echo Please specify the debug port after the --debug option
+echo Please specify the debug port after the --java.debug option
 goto end
 
 :doneStart


### PR DESCRIPTION
Fix https://github.com/ballerinalang/ballerina/issues/2608

This PR will change java level debugging option to --java.debug which was earlier --debug

Note that this PR doesn't change the --debug option in the composer.sh file and composer.bat files, so they have still --debug for java debug