### PR TITLE
Fix of WebSocket Intermittent Test Case Failures

### DIFF
--- a/modules/tests/test-integration/pom.xml
+++ b/modules/tests/test-integration/pom.xml
@@ -65,6 +65,11 @@
             <artifactId>mina-core</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/modules/tests/test-integration/src/test/java/org/ballerinalang/test/service/websocket/sample/WebSocketIntegrationTest.java
+++ b/modules/tests/test-integration/src/test/java/org/ballerinalang/test/service/websocket/sample/WebSocketIntegrationTest.java
@@ -2,7 +2,6 @@ package org.ballerinalang.test.service.websocket.sample;
 
 import org.ballerinalang.test.IntegrationTestCase;
 import org.ballerinalang.test.util.websocket.client.WebSocketClient;
-import org.testng.Assert;
 
 import java.net.URISyntaxException;
 import javax.net.ssl.SSLException;
@@ -25,20 +24,5 @@ public class WebSocketIntegrationTest extends IntegrationTestCase {
                 client.shutDown();
             }
         }
-    }
-
-    protected void assertWebSocketClientStringMessage(WebSocketClient client, String expectedValue,
-                                                      int threadSleepTime, int messageDeliveryCountDown)
-            throws InterruptedException {
-        String realValue = null;
-        for (int j = 0; j < messageDeliveryCountDown; j++) {
-            Thread.sleep(threadSleepTime);
-            realValue = client.getTextReceived();
-            if (realValue != null) {
-                Assert.assertEquals(realValue, expectedValue);
-                return;
-            }
-        }
-        Assert.assertEquals(realValue, expectedValue);
     }
 }

--- a/modules/tests/test-integration/src/test/java/org/ballerinalang/test/service/websocket/sample/WebSocketPassThroughTestCase.java
+++ b/modules/tests/test-integration/src/test/java/org/ballerinalang/test/service/websocket/sample/WebSocketPassThroughTestCase.java
@@ -61,7 +61,7 @@ public class WebSocketPassThroughTestCase extends WebSocketIntegrationTest {
                                  "websocket" + File.separator + "SimpleProxyServer.bal").getAbsolutePath();
         ballerinaServer.startBallerinaServer(balFilePath);
 
-        // Initializing WebSocket clients.
+        // Initializing and handshaking WebSocket clients.
         for (int i = 0; i < clientCount; i++) {
             wsClients[i] = new WebSocketClient("ws://localhost:9090/proxy/ws");
         }

--- a/modules/tests/test-integration/src/test/resources/testng.xml
+++ b/modules/tests/test-integration/src/test/resources/testng.xml
@@ -23,11 +23,11 @@
     </listeners>
 
     <!-- Below tests should run sequentially since it will use same port in each test -->
-    <test name="ballerina-sample-tests" preserve-order="true" parallel="false">
-        <packages>
-            <package name="org.ballerinalang.test.service.http.sample"/>
-        </packages>
-    </test>
+    <!--<test name="ballerina-sample-tests" preserve-order="true" parallel="false">-->
+        <!--<packages>-->
+            <!--<package name="org.ballerinalang.test.service.http.sample"/>-->
+        <!--</packages>-->
+    <!--</test>-->
 
     <test name="ballerina-web-socket-sample-tests" preserve-order="true" parallel="false">
         <classes>

--- a/modules/tests/test-integration/src/test/resources/testng.xml
+++ b/modules/tests/test-integration/src/test/resources/testng.xml
@@ -23,11 +23,11 @@
     </listeners>
 
     <!-- Below tests should run sequentially since it will use same port in each test -->
-    <!--<test name="ballerina-sample-tests" preserve-order="true" parallel="false">-->
-        <!--<packages>-->
-            <!--<package name="org.ballerinalang.test.service.http.sample"/>-->
-        <!--</packages>-->
-    <!--</test>-->
+    <test name="ballerina-sample-tests" preserve-order="true" parallel="false">
+        <packages>
+            <package name="org.ballerinalang.test.service.http.sample"/>
+        </packages>
+    </test>
 
     <test name="ballerina-web-socket-sample-tests" preserve-order="true" parallel="false">
         <classes>


### PR DESCRIPTION
This PR fixes intermittent test case failures due to the usage of thread sleep in test cases. 

This also resolves https://github.com/ballerinalang/tools-distribution/issues/203